### PR TITLE
Fixing the "wall_time" parameter to "job_wall_time"

### DIFF
--- a/FabDummy.py
+++ b/FabDummy.py
@@ -31,7 +31,7 @@ def dummy(config, **args):
     update_environment(args)
     with_config(config)
     execute(put_configs, config)
-    job(dict(script='dummy', wall_time='0:15:0', memory='2G'), args)
+    job(dict(script='dummy', job_wall_time='0:15:0', memory='2G'), args)
 
 
 @task


### PR DESCRIPTION
The task `dummy` in `FabDummy.py` creates a job with the parameter `wall_time`.
The inserted time however is not propagated to the final batch-script for all existing templates.
Templates expect the parameter `job_wall_time` to be set.

Fixing this is as simple as adapting the parameter name in the dictionary passed to the `job`-function.